### PR TITLE
chore: override serializer

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -32,7 +32,16 @@ services:
     arguments:
       $safelist: '%rollbar.config.scrub_safelist%'
       $scrubEnvVariables: '%rollbar.config.scrub_env_variables%'
-  SFErTrack\RollbarSymfonyBundle\Service\PersonProvider\PersonProviderFacade: ~
   SFErTrack\RollbarSymfonyBundle\Service\CheckIgnore\CheckIgnoreFacade: ~
   SFErTrack\RollbarSymfonyBundle\Service\Exception\ExceptionExtraDataFacade: ~
   SFErTrack\RollbarSymfonyBundle\Service\Exception\ExceptionExtraDataProvider: ~
+
+  sfertrack.serializer.rollbar_serializer_factory:
+    autoconfigure: false
+    class: 'Symfony\Component\Serializer\Serializer'
+    factory: '@SFErTrack\RollbarSymfonyBundle\Serializer\RollbarSerializerFactory'
+
+  SFErTrack\RollbarSymfonyBundle\Service\PersonProvider\PersonProviderFacade:
+    class: SFErTrack\RollbarSymfonyBundle\Service\PersonProvider\PersonProviderFacade
+    arguments:
+      $normalizer: '@sfertrack.serializer.rollbar_serializer_factory'

--- a/src/Serializer/RollbarSerializerFactory.php
+++ b/src/Serializer/RollbarSerializerFactory.php
@@ -1,0 +1,29 @@
+<?php
+
+
+declare(strict_types=1);
+
+namespace SFErTrack\RollbarSymfonyBundle\Serializer;
+
+use Symfony\Component\Serializer\Encoder\JsonEncoder;
+use Symfony\Component\Serializer\Normalizer\ArrayDenormalizer;
+use Symfony\Component\Serializer\Normalizer\BackedEnumNormalizer;
+use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
+use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
+use Symfony\Component\Serializer\Serializer;
+
+class RollbarSerializerFactory
+{
+    public function __invoke(): Serializer
+    {
+        $encoders = [new JsonEncoder()];
+        $normalizers = [
+            new DateTimeNormalizer(),
+            new ArrayDenormalizer(),
+            new BackedEnumNormalizer(),
+            new ObjectNormalizer(),
+        ];
+
+        return new Serializer($normalizers, $encoders);
+    }
+}


### PR DESCRIPTION
In Api Platform, the default serializer dependencies include a logger that pulls RollbarHandler, which causes a circular dependency.